### PR TITLE
Allow setting project-ref and access-token in config file

### DIFF
--- a/bin/supabase_helper.dart
+++ b/bin/supabase_helper.dart
@@ -5,9 +5,8 @@ import 'package:supabase_helper/supabase_helper.dart';
 
 Future<void> main(List<String> args) async {
   final parser = ArgParser()
-    ..addOption('project-ref',
-        help: 'Supabase project reference ID', mandatory: true)
-    ..addOption('access-token', help: 'Supabase access-token', mandatory: true)
+    ..addOption('project-ref', help: 'Supabase project reference ID')
+    ..addOption('access-token', help: 'Supabase access-token')
     ..addOption('output', abbr: 'o')
     ..addOption('config', abbr: 'c', defaultsTo: 'supabase_helper.yaml');
   print('✅  Supabase Helper is powering up!');
@@ -16,11 +15,21 @@ Future<void> main(List<String> args) async {
   final configFile = File(results['config'] as String);
   final config = GeneratorConfig.fromYaml(await configFile.readAsString());
   final outputDir = results['output'] as String? ?? config.outputDir;
+
+  final projectRef = results['project-ref'] as String? ?? config.projectRef;
+
+  final accessToken = results['access-token'] as String? ?? config.accessToken;
+  if (projectRef == null) {
+    throw ArgumentError('Supabase project reference ID is not provided. '
+        'Please provide it via --project-ref option or in the config file.');
+  }
+  if (accessToken == null) {
+    throw ArgumentError('Supabase access-token is not provided. '
+        'Please provide it via --access-token option or in the config file.');
+  }
   print(' Output directory: $outputDir');
-  final api = SupabaseManagementApi(
-    projectRef: results['project-ref'] as String,
-    accessToken: results['access-token'] as String,
-  );
+  final api =
+      SupabaseManagementApi(projectRef: projectRef, accessToken: accessToken);
 
   try {
     late List<String> enumNames = [];

--- a/lib/src/config/config.dart
+++ b/lib/src/config/config.dart
@@ -31,13 +31,12 @@ class GeneratorConfig {
 
   factory GeneratorConfig.fromYaml(String content) {
     final yaml = loadYaml(content);
-    final projectRef = yaml['project-ref'] as String?;
-    final accessToken = yaml['access-token'] as String?;
+    final projectRef = yaml['project-ref']?.toString();
+    final accessToken = yaml['access-token']?.toString();
     final enumConfig = yaml['enums'] ?? {};
     final tableConfig = yaml['tables'] ?? {};
     final functionConfig = yaml['functions'] ?? {};
     final isarConfig = yaml['isar'] ?? {};
-    print('isarConfig: $isarConfig');
 
     return GeneratorConfig(
       projectRef: projectRef,

--- a/lib/src/config/config.dart
+++ b/lib/src/config/config.dart
@@ -1,6 +1,8 @@
 import 'package:yaml/yaml.dart';
 
 class GeneratorConfig {
+  final String? projectRef;
+  final String? accessToken;
   final bool generateEnums;
   final bool generateTables;
   final bool generateFunctions;
@@ -13,6 +15,8 @@ class GeneratorConfig {
   final String outputDir;
 
   GeneratorConfig({
+    this.projectRef,
+    this.accessToken,
     required this.generateEnums,
     required this.generateTables,
     required this.generateFunctions,
@@ -27,6 +31,8 @@ class GeneratorConfig {
 
   factory GeneratorConfig.fromYaml(String content) {
     final yaml = loadYaml(content);
+    final projectRef = yaml['project-ref'] as String?;
+    final accessToken = yaml['access-token'] as String?;
     final enumConfig = yaml['enums'] ?? {};
     final tableConfig = yaml['tables'] ?? {};
     final functionConfig = yaml['functions'] ?? {};
@@ -34,6 +40,8 @@ class GeneratorConfig {
     print('isarConfig: $isarConfig');
 
     return GeneratorConfig(
+      projectRef: projectRef,
+      accessToken: accessToken,
       generateEnums: enumConfig['disabled'] == true ? false : true,
       generateTables: tableConfig?['disabled'] == true ? false : true,
       generateFunctions: functionConfig?['disabled'] == true ? false : true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supabase_helper
 description: Generates Dart models/enums/functions from Supabase. Add annotation to your generated classes automatically.
-version: 0.0.4
+version: 0.0.5
 repository: https://github.com/raoul-m/supabase_helper
 
 environment:


### PR DESCRIPTION
The `project-ref` and `access-token` can now be specified in the `supabase_helper.yaml` configuration file. Command-line arguments for these values are now optional and will override the settings from the config file if provided.