### PR TITLE
Refactor config parsing to use `toString()` and remove debug print

### DIFF
--- a/lib/src/generators/table_generator.dart
+++ b/lib/src/generators/table_generator.dart
@@ -89,7 +89,7 @@ class TableGenerator {
               .join(',\n'))
           ..writeln('\n });');
 
-// fromJson
+        // fromJson
         classBuffer
           ..writeln(
               '\n  factory $className.fromJson(Map<String, dynamic> json) => $className(')
@@ -146,6 +146,16 @@ class TableGenerator {
           ..writeln('    );')
           ..writeln('  }')
           ..writeln('}');
+
+        // toString
+        classBuffer
+          ..writeln('\n  @override')
+          ..writeln('  String toString() {')
+          ..writeln('    return \'$className(${columns.map((c) {
+            final fieldName = toCamelCase(c.name);
+            return '$fieldName: \$$fieldName';
+          }).join(', ')})\';')
+          ..writeln('  }');
 
         final importBuffer = StringBuffer();
 


### PR DESCRIPTION
This pull request adds an override for the `toString` method in the `TableGenerator` class to improve debugging and readability of generated table classes.

Key change:

* [`lib/src/generators/table_generator.dart`](diffhunk://#diff-558454e2f7b3ccfa23b80d7d256d8c63edee29ef01840257d17b832e43656094R150-R159): Added a `toString` method that formats the class name and its fields into a readable string representation, using the column names converted to camel case.